### PR TITLE
Wird getrumpft, wird die falsche Karte als Stich markiert.

### DIFF
--- a/flutter_ui/lib/main.dart
+++ b/flutter_ui/lib/main.dart
@@ -663,6 +663,7 @@ class WizardModel implements GameMsgVisitor<void, void>, GameCmdVisitor<void, St
     roundInfo = self;
     activityState.startRound(self.players, self.startPlayer);
     trumpCard.value = self.trumpCard;
+    trump = self.trumpCard?.suit;
     myCards.set(self.cards);
     
     setState(WizardPhase.cardsGiven);


### PR DESCRIPTION
Falsche Anzeige des Stiches korrigiert.